### PR TITLE
[GITOPS] - Merging 'docs/add-how-to-setup-tag-on-main-guide' in 'release' - Initiate Release Process

### DIFF
--- a/docs/guides/gitops/index.md
+++ b/docs/guides/gitops/index.md
@@ -41,6 +41,14 @@ For more on what is `Git Ops` and `Git Ops Processes` see the [Git Ops Topics Pa
 
     [:octicons-arrow-right-24: Setup ](./setup/guide_setup_main_manual_acceptance.md)
 
+-   :material-clock-fast:{ .lg .middle } __Setup Automatic Tagging on Main__
+
+    ---
+
+    Automatically Tag Commit on Main, with Semantic Version
+
+    [:octicons-arrow-right-24: Setup ](./setup/guide_setup_auto_tag_main.md)
+
 -   :material-clock-fast:{ .lg .middle } __Setup Automatic Clean-Up__
 
     ---

--- a/docs/guides/gitops/setup/guide_setup_auto_tag_main.md
+++ b/docs/guides/gitops/setup/guide_setup_auto_tag_main.md
@@ -1,0 +1,62 @@
+---
+tags:
+  - how-to
+  - guide
+---
+
+# Automatically `Tag Commit` on `main`, after PR merge
+
+This guide shows you how to include `Automatic Tagging on main` with **Semantic Version** tag, in your `Release Me` **Git Ops Process**.
+
+## Prerequisites
+- a `github repository`
+- account with permission to **Repository Settings**
+
+## Guide
+
+To **automatically tag** the commit on `main/master` branch, after **Code Merge** from `release` branch, via a PR bearing the `auto-deploy` label, follow below steps.
+
+### 1. Create a Workflow, that when Triggered creates a Git Tag
+
+Populate file `.github/workflows/gitops-tag-main.yml` with content:
+{% raw %}
+```yaml
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - master
+jobs:
+  tag_main:
+    # if code merged to 'main/master' br, via PR from 'release' br bearing the 'auto-deploy' label
+    if: github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'release' &&
+      contains(github.event.pull_request.labels.*.name, 'auto-deploy')
+    uses: boromir674/automated-workflows/.github/workflows/go-tag-main.yml@18b20a331650752492a8ed614feb4057216b6547  # v1.12.0
+    with:
+      gh_username: ${{ vars.TAG_USER_NAME }}
+      gh_email: ${{ vars.TAG_USER_EMAIL }}
+      main_branch: ${{ github.event.pull_request.base.ref }}
+    secrets:
+      # needs Content write to create Tag!
+      # needs Actions write to allow other workflows to listen to tag event!
+      GH_PAT_ACTION_RW: ${{ secrets.GH_TOKEN_CONTENT_ACTIONS_RW }}
+```
+{% endraw %}
+to create a Github Action Workflow that can **automatically tag** the commit on `main/master` branch and triggers only when **Code Merges** to `main/master` from `release` branch via a PR that must bear the `auto-deploy` label.
+
+ [//]: # (This is a comment)
+
+### 2. Grant required Permissions to create remote Git Tags
+
+  1. Generate a **PAT**, scoped for your repository, bearing the `read/write` permission for:
+     - *Contents*
+     - *Actions*
+  2. Make PAT available to your repo as a `Repository Secret`
+     1. Create **Repository Secret** with **name** `GH_TOKEN_CONTENT_ACTIONS_RW`
+     2. Set the `GH_TOKEN_CONTENT_ACTIONS_RW` **Repository Secret Value** to the generated **PAT**
+
+## Congratulations :partying_face:
+
+Now, you should have **automated** the **Publishing of Tag**, when running your `Release Me` **Git Ops Process**!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
             - "Setup Release Me - Phase 2": "guides/gitops/setup/guide_setup_gitops_release_me_phase_2.md"
             - "Automated Acceptance": "guides/gitops/setup/guide_setup_main_automated_acceptance.md"
             - "Manual Acceptance": "guides/gitops/setup/guide_setup_main_manual_acceptance.md"
+            - "Automatic Tag on Main": "guides/gitops/setup/guide_setup_auto_tag_main.md"
             - "Automatic Clean-Up": "guides/gitops/setup/guide_setup_automatic_tags_deletion.md"
           - "RUN":
             - "Release Me": "guides/gitops/run/guide_run_gitops_release_me_process.md"


### PR DESCRIPTION
## :rocket: Initiating Release Process :rocket:

  This PR marks a pivotal moment in our deployment cycle, signaling that all changes on the **Release Train (RT)** are deemed ready for release. It represents the collective decision of our developers that the changes bundled in the RT are suitable to be released together.

  ### What's Happening in This PR?

  - We are merging the  branch into the  branch.
  - This action is a critical step, transitioning us from the development phase to the release phase.

  ### :white_check_mark: Automatic Merging Upon CI Checks :white_check_mark:

  - This PR is configured to **automatically merge** once all CI checks successfully pass.
  - These checks include running our comprehensive test suite on the RT branch to ensure a minimum standard of quality, covering sanity checks, QA, and unit tests.

  ### Ensuring Quality and Preparing for Release:

  - Our focus now shifts to **stress testing** and on CI.
  - We'll also handle essential chores, like updating the changelog with a new entry dedicated for the imminent release.

  ### :bulb: Next Steps in Our Journey:

  - Following the successful merge of this PR, we'll initiate the next phase, which involves merging the  into the **** branch.

  ### :hourglass_flowing_sand: Looking Ahead:

  - Once merged, our changes are set for the final stage of release preparation.
  