### PR TITLE
[GITOPS] - Merging 'release' in 'main' - Releasing into Production

### DIFF
--- a/.github/workflows/go-auto-merge-main.yml
+++ b/.github/workflows/go-auto-merge-main.yml
@@ -136,6 +136,8 @@ jobs:
       ## LABEL PR for Auto Deploy, to trigger 'Tag Main' Workflow after merge ##
       - name: Search for 'auto-deploy', among the registered Repository PR Labels
         run: echo AUTO_DEPLOY_LABEL_OBJECT="$(gh label list --json id,name,description,isDefault --jq '.[] | select(.name == "auto-deploy")')" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.pat_token }}
       - name: Register 'auto-deploy', in Repository PR Labels, if not already present
         if: ${{ env.AUTO_DEPLOY_LABEL_OBJECT != '' }}
         run: |

--- a/.github/workflows/go-pr-to-main.yml
+++ b/.github/workflows/go-pr-to-main.yml
@@ -45,6 +45,21 @@ jobs:
           set-safe-directory: ''  # `git config --global --add safe.directory <path>`
           token: '${{ secrets.PR_RW_AND_ACTIONS_RW }}'
 
+      - name: Find most recently pushed Git Tag v*
+        run: echo "LATEST_SEMVER_TAG=$(git tag -l 'v*' | sort -V | tail -n 1)" >> $GITHUB_ENV
+
+      - name: Generate Linear Commit History from HEAD to main
+        id: commit_generator
+        uses: boromir674/action-commit-parser@v1.0.0
+        with:
+          # we do not override input.from_ref to use whatever we checked out with actions/checkout
+          to_ref: ${{ env.LATEST_SEMVER_TAG }}
+
+        # ommit oldest commit since somehow (todo investigate) it is expected to be the latest merge commit on main !
+        # Yaml string is formatted into JSON github expression, which is a ready-to-use quoted thing to use in shell/bash
+      - name: Store JSON Array of objects as JSON Array of strings, in a GITHUB_ENV Variable
+        run: echo COMMITS_ARRAY=$(echo ${{ toJSON(steps.commit_generator.outputs.commits_array) }} | jq -c '[.[0:-1] | .[].message]') >> $GITHUB_ENV
+
       ##### Open PR: Release  -->  Main/Master #####
       - name: "Open PR  'head': ${{ env.RELEASE }} --> 'base': ${{ env.MAIN_BR }}"
         env:
@@ -53,24 +68,36 @@ jobs:
           gh pr create --head "${{ env.RELEASE }}" --base "${{ env.MAIN_BR }}" \
             --title "[GITOPS] - Merging '${{ env.RELEASE }}' in '${{ env.MAIN_BR }}' - Releasing into Production" \
             --body "## :rocket: Releasing into Production :rocket:
-            
-            This PR marks a pivotal moment in our deployment cycle, signaling that all changes on the **Release** branch are deemed ready for production.  
-            It represents the collective decision of our developers that the changes bundled in the Release are suitable to be released together.
 
-            ### What's Happening in This PR?
+          This PR signals our \`intention\` to
+          - **Continue the Release Process**
 
-            - We are merging the '${{ env.RELEASE }}' branch into the '${{ env.MAIN_BR }}' branch.
-            - This is the last Pull Request, transitioning us from the release phase to the production phase.
+          ### :point_right: Changes
+          $(echo ${COMMITS_ARRAY} | jq -r | jq -r '.[]' | awk '{print "- " $0}')
 
-            ### :white_check_mark: Automatic Merging Upon CI Checks :white_check_mark:
-            
-            Before merging into '${{ env.MAIN_BR }}', this PR **should be checked**, for meetings some standards, such as:
+          ### What's Happening in This PR?
 
-            - All CI Jobs are Green / Passing
-            - Acceptance Criteria/Tests passed, on a Staging Deployment
-            - Code Review is approved by at least one developer
+          - We are merging the \`${{ env.RELEASE }}\` branch into the \`${{ env.MAIN_BR }}\` branch.
+          - This action is typically an intermediate Step in the \`Release Process\`, where we **prepare** the changes for the **Release**.
+            - Eg: Updating the **Changelog** file
+            - Eg: Updating the **Version** file. if maintained
+          - This is the last Pull Request, transitioning us from the \`release\` phase to the \`production\` phase.
 
-            "
-        # ### :warning: Manual Merging Upon CI Checks and Code Review :warning:
+          \`\`\`mermaid
+          ---
+          title: Typical 2-PR Release Process
+          ---
+          graph LR
+            A[User Branch] -->|PR| B[Release Branch]
+            B -->|PR| C[Main Branch]
+          \`\`\`
 
-        # If the above conditions are not met, this PR will be manually merged into the '${{ env.MAIN_BR }}' branch, by a developer.
+          ### :white_check_mark: Automatic Merging Upon CI Checks :white_check_mark:
+
+          **Before merging** into '${{ env.MAIN_BR }}', this PR **should be checked**, for meeting **standards**, such as:
+
+          - All CI Jobs are Green / Passing
+          - Acceptance Criteria/Tests passed, on a Staging Deployment
+          - Code Review is approved by at least one developer
+          "
+

--- a/.github/workflows/go-pr-to-release.yml
+++ b/.github/workflows/go-pr-to-release.yml
@@ -24,11 +24,16 @@ on:
         type: string
         description: "Branch with 'Release' Purpose"
         default: 'release'
+      main_branch:
+        required: false
+        type: string
+        description: "Branch with 'Main' Purpose"
+        default: 'main'
       backwords_compatibility:
         required: false
         type: string
         description: >
-          "Etheir 'backwords-compatible' or 'backwords-incompatible'.
+          "Either 'backwords-compatible' or 'backwords-incompatible'.
           If 'backwords-incompatible', then it hints for major Sem Ver bump, if this released.
           If 'backwords-compatible', then when this is the only change for release, it hints for patch or minor Sem Ver bump.
           If 'backwords-compatible', then when there are more changes for release, this does not impose minimum Bump level.
@@ -36,7 +41,7 @@ on:
         default: ''
       forbidden_branches:
         required: false
-        default: 'main,master'
+        default: 'main,master,release'
         description: >
           "Comma separated list of branches, which are forbidden to be merged into Release Branch.
           Set to main,master to crash this Job, in case accidentally the main/master branch was
@@ -111,6 +116,7 @@ jobs:
         run: |
           echo "Input **Backwords Compatibility**: ${{ inputs.backwords_compatibility }}" >> $GITHUB_STEP_SUMMARY
           echo BACKWORDS_COMPATIBILITY=${{ inputs.backwords_compatibility }} >> $GITHUB_ENV
+          echo CLI_FLAG="--label ${{ inputs.backwords_compatibility }}" >> $GITHUB_ENV
 
       - name: 'Warn, if unsupported value for backwords_compatibility'
         if: ${{ inputs.backwords_compatibility != 'backwords-compatible' && inputs.backwords_compatibility != 'backwords-incompatible' }}
@@ -124,41 +130,66 @@ jobs:
           echo BACKWORDS_COMPATIBILITY='' >> $GITHUB_ENV
 
       ####### PR: User Branch --> Release #######
+      # TODO: auto populate section '### :white_check_mark: Automatic Merging Upon CI Checks :white_check_mark:' inside PR Body
+      #    - Automatically GET with Gh API the Required Checks matching the release branch rule
+      #    - use YAML to parse Single QA Job Required/allowed_skip/allowed_fail Inputs
+      #    - use above info to populate the PR Body section
 
+      - name: Find most recently pushed Git Tag v*
+        run: echo "LATEST_SEMVER_TAG=$(git tag -l 'v*' | sort -V | tail -n 1)" >> $GITHUB_ENV
+
+      - name: Generate Linear Commit History from HEAD to main
+        id: commit_generator
+        uses: boromir674/action-commit-parser@v1.0.0
+        with:
+          # we do not override input.from_ref to use whatever we checked out with actions/checkout
+          to_ref: ${{ env.LATEST_SEMVER_TAG }}
+
+        # Yaml string is formatted into JSON github expression, which is a ready-to-use quoted thing to use in shell/bash
+        # ommit oldest commit since somehow (todo investigate) it is expected to be the latest merge commit on main !
+      - name: Store JSON Array of objects as JSON Array of strings, in a GITHUB_ENV Variable
+        run: echo COMMITS_ARRAY=$(echo ${{ toJSON(steps.commit_generator.outputs.commits_array) }} | jq -c '[.[0:-1] | .[].message]') >> $GITHUB_ENV
+
+      ## Create PR ##
       - name: "Create PR  'head': ${{ env.USER_BRANCH }}  -->  'base': ${{ inputs.release_branch }}"
         env:
           GH_TOKEN: ${{ secrets.github_pat }}
         run: |
-          gh pr create --head "${{ env.USER_BRANCH }}" --base "${{ inputs.release_branch }}" \
-            ${{ env.BACKWORDS_COMPATIBILITY && '--label env.BACKWORDS_COMPATIBILITY' || '' }} \
-            --title "[GITOPS] - Merging '${{ env.USER_BRANCH }}' in '${{ inputs.release_branch }}' - Initiate Release Process" \
-            --body "## :rocket: Initiating Release Process :rocket:
+          gh pr create --head "${{ env.USER_BRANCH }}" --base "${{ inputs.release_branch }}" ${{ env.CLI_FLAG }} \
+            --title "[GITOPS] - Merging '${{ env.USER_BRANCH }}' in '${{ inputs.release_branch }}'" \
+            --body "## :steam_locomotive: **Marking for Release** all changes from **\`${{ env.USER_BRANCH }}\`** Branch :steam_locomotive:
 
-            This PR marks a pivotal moment in our deployment cycle, signaling that all changes on the **Release Train (RT)** are deemed ready for release. It represents the collective decision of our developers that the changes bundled in the RT are suitable to be released together.
+          This PR signals our \`intention\` to
+          - **Initiate the Release Process**
+          - include all changes from **${{ env.USER_BRANCH }}** branch in the Release.
 
-            ### What's Happening in This PR?
+          ### :large_blue_diamond: Changes
+          $(echo ${COMMITS_ARRAY} | jq -r | jq -r '.[]' | awk '{print "- " $0}')
 
-            - We are merging the `${{ env.USER_BRANCH }}` branch into the `${{ inputs.release_branch }}` branch.
-            - This action is a critical step, transitioning us from the development phase to the release phase.
+          ### What's Happening in This PR?
 
-            ### :white_check_mark: Automatic Merging Upon CI Checks :white_check_mark:
+          - We are merging the \`${{ env.USER_BRANCH }}\` branch into the \`${{ inputs.release_branch }}\` branch.
+          - We have decided that next Release should exactly include all changes from the \`${{ env.USER_BRANCH }}\` branch.
+          - This action is typically the 1st Step in the \`Release Process\`, where we **prepare** the changes for the **Release**.
 
-            - This PR is configured to **automatically merge** once all CI checks successfully pass.
-            - These checks include running our comprehensive test suite on the RT branch to ensure a minimum standard of quality, covering sanity checks, QA, and unit tests.
+          \`\`\`mermaid
+          ---
+          title: Typical 2-PR Release Process
+          ---
+          graph LR
+            A[User Branch] -->|PR| B[Release Branch]
+            B -->|PR| C[Main Branch]
+          \`\`\`
 
-            ### Ensuring Quality and Preparing for Release:
+          ### :bulb: Next Steps in Our Journey:
 
-            - Our focus now shifts to **stress testing** and on CI.
-            - We'll also handle essential chores, like updating the changelog with a new entry dedicated for the imminent release.
-
-            ### :bulb: Next Steps in Our Journey:
-
-            - Following the successful merge of this PR, we'll initiate the next phase, which involves merging the `${{ inputs.release_branch }}` into the **${{ env.MAIN_BR }}** branch.
-
-            ### :hourglass_flowing_sand: Looking Ahead:
-
-            - Once merged, our changes are set for the final stage of release preparation.
-            "
+          Following the successful merge of this PR, we can initiate the **next phase**, which involves for example:
+          - Ensuring \`Release Chores\` are completed, such as:
+            - Updating the **Changelog** file
+            - Updating the **Version** file. if maintained
+            - Generating the Github **Release Notes**
+          - \`Merging\` the \`${{ inputs.release_branch }}\` into the **${{ inputs.main_branch }}** branch.
+          "
 
       ##### Auto Merge: User Branch --> Release #####
       - name: 'Merge PR   ${{ env.USER_BRANCH }}  -->  ${{ inputs.release_branch }}'

--- a/.github/workflows/go-tag-main.yml
+++ b/.github/workflows/go-tag-main.yml
@@ -37,58 +37,35 @@ jobs:
         with:
           fetch-depth: 0  # 0 indicates all history for all branches and tags.
           set-safe-directory: ''  # `git config --global --add safe.directory <path>`
+          ref: ${{ inputs.main_branch }}
           token: '${{ secrets.GH_PAT_ACTION_RW }}'
 
-      - name: Ensure we are on '${{ inputs.main_branch }}' branch
-        run: git checkout "${{ inputs.main_branch }}"
+      # Find latest tag and derive Sem Ver
+      - name: Find most recently pushed Git Tag v*
+        run: echo "LATEST_GIT_TAG=$(git tag -l 'v*' | sort -V | tail -n 1)" >> $GITHUB_ENV
 
-      # Derive SEM VER from most recent tag
-      - name: "Search tags, filter out those not matching v* and find latest"
-        run: |
-          LATEST_GIT_TAG=$(git tag -l "v*" | sort -V | tail -n 1)
-          echo "[INFO]: Latest Git Tag: $LATEST_GIT_TAG"
-          echo "**Found Latest Git Tag: ${LATEST_GIT_TAG}**" >> $GITHUB_STEP_SUMMARY
+      - run: 'echo "**Most Recent Git Tag: ${{ env.LATEST_GIT_TAG }}**" >> $GITHUB_STEP_SUMMARY'
 
-          # remove starting v
-          SEM_VER="${LATEST_GIT_TAG:1:${#LATEST_GIT_TAG}}"
-          echo "**Derived Latest Release Sem Ver: ${SEM_VER}**" >> $GITHUB_STEP_SUMMARY
+      # if tag ends with '-rc' strip it and store remaining string
+      - if: contains(env.LATEST_GIT_TAG, '-rc')
+        run: echo PROD_GIT_TAG="${LATEST_GIT_TAG%-rc}" >> $GITHUB_ENV
 
-          # if tag ends with '-rc' strip it and store remaining string
-          if [[ $LATEST_GIT_TAG == *"-rc" ]]; then
-            # PROD_SEM_VER=${LATEST_GIT_TAG:1:${#LATEST_GIT_TAG}-4}
-            PROD_SEM_VER="${SEM_VER%-rc}"
+      - if: contains(env.LATEST_GIT_TAG, 'dev')
+        run: echo PROD_GIT_TAG="${LATEST_GIT_TAG}" >> $GITHUB_ENV
 
-          # else if dev substring is found then store as it is
-          elif [[ $LATEST_GIT_TAG == *"dev"* ]]; then
-            PROD_SEM_VER="${SEM_VER}"
-          else
-            echo "[INFO] Unexpected Git Tag: $LATEST_GIT_TAG"
-            echo "Exiting .."
-            exit 1
-          fi
+      - run: 'echo "- **New Sem Ver Release Tag: ${{ env.PROD_GIT_TAG }}**" >> $GITHUB_STEP_SUMMARY'
 
-          echo "- **New Sem Ver: ${PROD_SEM_VER}**" >> $GITHUB_STEP_SUMMARY
-          echo SEMVER=$PROD_SEM_VER >> $GITHUB_ENV
-
-      # Exit if Sem Ver is empty
-      - name: "Exit if SOURCE Sem Ver is empty"
-        run: |
-          if [ -z "${{ env.SEMVER }}" ]; then
-            echo "SEMVER is empty. Exiting .."
-            exit 1
-          fi
-
-      # Prepen 'v' to the Sem Ver
-      - name: 'Create Git Tag: v${{ env.SEMVER }}'
-        run: echo "PROD_TAG=v${{ env.SEMVER }}" >> $GITHUB_ENV
+      # if PROD_GIT_TAG is empty/not-populated
+      - if: env.PROD_GIT_TAG == ''
+        run: 'echo "[ERROR] Could not derive new Prod Release Git Tag from most recent discovered tag: ${{ env.LATEST_GIT_TAG }}. Exiting .." && exit 1'
 
       - run: git config --global user.name "${{ inputs.gh_username }}"
       - run: git config --global user.email "${{ inputs.gh_email }}"
 
-      # PUSH TAG in MAIN BRANCH
-      - name: "Push '${{ env.PROD_TAG }}' to trigger CI/CD for 'Production Release'"
+      ### PUSH TAG in MAIN BRANCH ###
+      - name: "Push '${{ env.PROD_GIT_TAG }}' to trigger CI/CD for 'Production Release'"
         run: |
-          git tag "${{ env.PROD_TAG }}" -m "Production Release ${{ env.PROD_TAG }}"
-          git push origin "${{ env.PROD_TAG }}"
+          git tag "${{ env.PROD_GIT_TAG }}" -m "Production Release ${{ env.PROD_GIT_TAG }}"
+          git push origin "${{ env.PROD_GIT_TAG }}"
 
-          echo "Tagged and Pushed '${{ env.PROD_TAG }}'" >> $GITHUB_STEP_SUMMARY
+          echo "Tagged and Pushed '${{ env.PROD_GIT_TAG }}'" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.13.0 (2024-09-23)
+
+### Changes
+
+#### Feature
+- better PR Title and Body contents, with **automatically parsed commit history**, for 'PR to main' Workflow
+- crash and report error if user is on release branch when opening PR to release
+- better PR Title and Body contents, with **automatically parsed commit history**, for PR to release
+
+#### Fix
+- properly pass dynamic flag in gh CLI based on backword-compatibility User Input
+- add permission for registering new label in available repository PR Labels
+- checkout main before Tag on main
+
+
 ## 1.12.1-dev1 (2024-09-21)
 
 ### Changes


### PR DESCRIPTION
## :rocket: Releasing into Production :rocket:

This PR signals our `intention` to
- **Continue the Release Process**

### :point_right: Changes
- Merge pull request #49 from boromir674/dev
- chore(changelog): add v1.13.0 Changelog Release Entry
- feat(pr): better PR Title and Body contents for 'PR to main' Workflow
- feat(pr): better PR Title and Body contents for PR to release
- fix(gitops): properly pass dynamic flag in gh CLI based on backword-compatibility User Input
- feat(gitops): crash and report error if user is on release branch when opening PR to release
- fix: add permission for registering new label in available repository PR Labels
- fix(gitops): checkout main before Tag on main

### What's Happening in This PR?

- We are merging the `release` branch into the `main` branch.
- This action is typically an intermediate Step in the `Release Process`, where we **prepare** the changes for the **Release**.
  - Eg: Updating the **Changelog** file
  - Eg: Updating the **Version** file. if maintained
- This is the last Pull Request, transitioning us from the `release` phase to the `production` phase.

```mermaid
---
title: Typical 2-PR Release Process
---
graph LR
  A[User Branch] -->|PR| B[Release Branch]
  B -->|PR| C[Main Branch]
```

### :white_check_mark: Automatic Merging Upon CI Checks :white_check_mark:

**Before merging** into 'main', this PR **should be checked**, for meeting **standards**, such as:

- All CI Jobs are Green / Passing
- Acceptance Criteria/Tests passed, on a Staging Deployment
- Code Review is approved by at least one developer
